### PR TITLE
ExcelService.Exception should be a RecoverableException

### DIFF
--- a/dom/src/main/java/org/isisaddons/module/excel/dom/ExcelService.java
+++ b/dom/src/main/java/org/isisaddons/module/excel/dom/ExcelService.java
@@ -37,7 +37,7 @@ import org.apache.isis.core.runtime.system.persistence.PersistenceSession;
 @DomainService
 public class ExcelService {
 
-    public static class Exception extends RuntimeException {
+    public static class Exception extends RecoverableException {
 
         private static final long serialVersionUID = 1L;
 


### PR DESCRIPTION
As for Isis help:
Indicates that an exceptional condition/problem has occurred within the application's domain logic. 
This exception should only be thrown for "recoverable" exceptions, that is, those which could be anticipated by the application
