### PR TITLE
Skip the all header's empty columns

### DIFF
--- a/dom/src/main/java/org/isisaddons/module/excel/dom/ExcelConverter.java
+++ b/dom/src/main/java/org/isisaddons/module/excel/dom/ExcelConverter.java
@@ -155,12 +155,14 @@ class ExcelConverter {
             for (final Row row : sheet) {
                 if (header) {
                     for (final Cell cell : row) {
-                        final int columnIndex = cell.getColumnIndex();
-                        final String propertyName = cellMarshaller.getStringCellValue(cell);
-                        final OneToOneAssociation property = getAssociation(objectSpec, propertyName);
-                        if (property != null) {
-                            final Class<?> propertyType = property.getSpecification().getCorrespondingClass();
-                            propertyByColumn.put(columnIndex, new Property(propertyName, property, propertyType));
+                        if (cell.getCellType() != Cell.CELL_TYPE_BLANK) {
+                            final int columnIndex = cell.getColumnIndex();
+                            final String propertyName = cellMarshaller.getStringCellValue(cell);
+                            final OneToOneAssociation property = getAssociation(objectSpec, propertyName);
+                            if (property != null) {
+                                final Class<?> propertyType = property.getSpecification().getCorrespondingClass();
+                                propertyByColumn.put(columnIndex, new Property(propertyName, property, propertyType));
+                            }
                         }
                     }
                     header = false;


### PR DESCRIPTION
Some Excel files contains "blank" columns after the ones initialized.
They don't have any information on them, but are treated as a "normal" column.
They should be skipped for avoiding a NPE as the property returned would be null for an empty (blank) header column name.
